### PR TITLE
content: update to zola 0.19

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,7 +1,6 @@
 +++
 title = "BlueOS"
 description = "Documentation for the BlueOS Docker software (replaces Companion)."
-date = 2021-10-20T20:30:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 1

--- a/content/development/_index.md
+++ b/content/development/_index.md
@@ -1,7 +1,6 @@
 +++
 title = "Development"
 description = "Documentation for the development of BlueOS."
-date = 2023-02-16T16:45:00+11:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 40

--- a/content/integrations/_index.md
+++ b/content/integrations/_index.md
@@ -1,7 +1,6 @@
 +++
 title = "Integrations"
 description = "Documentation for integrations with BlueOS."
-date = 2024-05-09T16:55:00+10:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 20

--- a/content/integrations/hardware/_index.md
+++ b/content/integrations/hardware/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Hardware"
 description = "Hardware documentation."
-date = 2022-10-04T01:21:30+10:00
-updated = 2022-10-04T22:00:00+10:00
 sort_by = "weight"
 weight = 2
 template = "docs/overview-section.html"

--- a/content/integrations/hardware/additional/_index.md
+++ b/content/integrations/hardware/additional/_index.md
@@ -1,7 +1,6 @@
 +++
 title = "Additional Components and Peripheral Devices"
 description = "Useful hardware for an underwater ROV."
-date = 2022-10-11T07:00:00+10:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 3

--- a/content/integrations/hardware/recommended/_index.md
+++ b/content/integrations/hardware/recommended/_index.md
@@ -1,7 +1,6 @@
 +++
 title = "Recommended Extra Hardware"
 description = "Hardware recommended for an underwater ROV."
-date = 2022-10-11T07:00:00+10:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 2

--- a/content/integrations/hardware/required/_index.md
+++ b/content/integrations/hardware/required/_index.md
@@ -1,7 +1,6 @@
 +++
 title = "Required Hardware"
 description = "Hardware required for an underwater ROV."
-date = 2022-10-04T21:45:00+10:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 1

--- a/content/usage/_index.md
+++ b/content/usage/_index.md
@@ -1,7 +1,6 @@
 +++
 title = "Usage"
 description = "Documentation for usage of BlueOS."
-date = 2024-05-09T16:45:00+10:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 10


### PR DESCRIPTION
The update date causes problems in the section metadata in recent zola versions.

I updated the action without updating my local version, so didn't realise until the action was building it. I've updated locally now, which should avoid similar issues in future, although I will need to update the other branches as well.

This is at least a good test of the PR preview deployment process 🤷‍♂️  :-)