### PR TITLE
config.toml: specify logo image URL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,6 +29,9 @@ include_content = true
 # Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
 highlight_code = true
 
+[extra.logo]
+image_source = "https://blueos.cloud/assets/img/blueos-logo-white.png"
+
 [[extra.license]]
 name = "AGPLv3"
 url = "https://github.com/bluerobotics/BlueOS?tab=AGPL-3.0-3-ov-file"


### PR DESCRIPTION
Required for latest theme update (bluerobotics/bluetheme#26).