### PR TITLE
Fix broken extensions links

### DIFF
--- a/content/development/extensions/index.md
+++ b/content/development/extensions/index.md
@@ -6,6 +6,7 @@ template = "docs/page.html"
 sort_by = "weight"
 weight = 40
 draft = false
+aliases = ['/usage/extensions']
 
 [extra]
 lead = ''

--- a/content/usage/advanced/index.md
+++ b/content/usage/advanced/index.md
@@ -179,7 +179,7 @@ is wide enough, the sidebar automatically stays open.
 
 - The theme content at the top [is configurable](#theme-content)
 {% pirate() %}
-- [The development documentation](../development/extensions/#web-interface-http-server)
+- [The development documentation](@/development/extensions/index.md#web-interface-http-server)
 specifies the requirements for a service page to appear in the sidebar
 {% end %}
 
@@ -703,7 +703,7 @@ it automatically (via MAVLink)
 {{ service(service="Kraken", port=9134, link="/services/kraken", based=true) }}
 
 The Extensions Manager is in charge of fetching, installing, updating, and managing
-[Extensions](../extensions).
+[Extensions](@/development/extensions/index.md).
 
 The Store tab shows the available extensions, with a default filter which excludes
 the development example extensions.

--- a/content/usage/overview/index.md
+++ b/content/usage/overview/index.md
@@ -108,7 +108,7 @@ BlueOS has almost all features from the old Companion, and several hotly-request
 | [**Ping Sonar Devices**](../advanced/#ping-sonar-devices) | &rarr; | &rarr; | &rarr; | &rarr;<br>+ Detects Ping360 in ethernet configuration<br>+ Ping Sonar distance estimates can be *sent via MAVLink* | &rarr;<br>+ Devices can be *hot-plugged*<br><br>- *No MAVLink pipeline* | Ping Sonar and Ping360 can connect with [Ping Viewer](https://docs.bluerobotics.com/ping-viewer/)<br>+ Ping Sonar distance estimates can be *sent via MAVLink* |
 | [**Serial Bridges**](../advanced/#serial-bridges) | &rarr; | &rarr;<br>+ Separate target and listener ports | &rarr; | &rarr; | &rarr; | Create and manage bridges between serial and UDP/TCP endpoints |
 | **Water Linked** | &rarr; | &rarr;<br>+ [UGPS and DVL fusion](https://waterlinked.github.io/dvl/bluerov-integration-dvl-ugps/#mode-dvlugps-fusing-the-data-of-underwater-gps-and-dvl-for-a-position-estimate-of-the-bluerov) | &rarr; | DVL-A50 and UGPS extensions available through Extensions Manager | [DVL-A50 package available](https://discuss.bluerobotics.com/t/external-integrations-extensions/10912#integration-example-dvl-5) | Supports UGPS and DVL-A50 |
-| [**Extensions**](../extensions/) | &rarr;<br>+ Improved interface parameters | &rarr; | &rarr; | Custom extensions available through Extensions Manager | &rarr; | Custom functionality requires forking the codebase |
+| [**Extensions**](@/development/extensions/index.md) | &rarr;<br>+ Improved interface parameters | &rarr; | &rarr; | Custom extensions available through Extensions Manager | &rarr; | Custom functionality requires forking the codebase |
 {% end %}
 
 ## Release Types


### PR DESCRIPTION
# 🔎 [PREVIEW](http://br-www-docs.s3-website-us-east-1.amazonaws.com/preview/blueos/52/usage/advanced/#extensions) 🔍

Raised by Elisa - incorrectly linking to the wrong parent section for the extensions page.