### PR TITLE
content: installation: cover SD card class recommendations

### DIFF
--- a/content/usage/installation.md
+++ b/content/usage/installation.md
@@ -21,6 +21,11 @@ It is compatible with **Raspberry Pi 3**, **4**, and **5**.
 
 [![Latest Beta](https://img.shields.io/github/v/tag/bluerobotics/blueos.svg?label=Latest%20Beta)![Date](https://img.shields.io/github/release-date-pre/bluerobotics/blueos?label=Date)](https://github.com/bluerobotics/blueos/releases)
 
+{% note() %}
+SD cards come in a variety of speed and performance classes, to suit different applications. As an operating system, **BlueOS should be run using a card with _at least_ an A1 [Application Performance Class](https://en.wikipedia.org/wiki/SD_card#Performance_ratings)**, to avoid degraded performance and system throttling.<br><br>
+Critical use-cases are recommended to use A2 cards, and systems intended for onboard recording of one or more video streams should use cards with a suitable [Video Speed Class](https://en.wikipedia.org/wiki/SD_card#Video_speed_class_(V)) rating (and appropriate total capacity) for the expected sustained data rates and file sizes.
+{% end %}
+
 Recommended operating system images of the latest stable version can be downloaded here:
 
 | Board Hardware | Image File (with Base OS) | Notes |


### PR DESCRIPTION
# 🔎 [PREVIEW](http://br-www-docs.s3-website-us-east-1.amazonaws.com/preview/blueos/63/usage/installation/) 🔍

@voorloopnul suggested we add a warning/note about minimum SD card speeds, given some issues we've run into with people experiencing degraded performance when using old / low specification SD cards. From looking into the variety of available designations, this seems to represent some reasonable expectations:

<img width="650" alt="SD card note preview" src="https://github.com/user-attachments/assets/f6b0dd0d-2518-47be-8436-1f5e041ce18b" />

I have included it on the installation page, as that's where it's most likely to be seen by users who do not buy a system with BlueOS pre-installed.

I'm undecided on whether it's worth including a warning about low quality cards that lie about their specs, or if that's excessive / out of scope.

bluerobotics/BlueOS#2405 would also be valuable, as a conditional check (regardless of _stated_ ratings, including for degradation over time), and for a potential warning directly in the software, but a warning in the docs is at least a start (and hopefully helps avoid _some_ issues before they even happen).