### PR TITLE
[Hotfix] usage: installation: temporarily hardcode to 1.4.2

### DIFF
--- a/content/usage/installation.md
+++ b/content/usage/installation.md
@@ -65,7 +65,7 @@ For developers with alternative hardware, or who would rather install over a pre
 
 <script type="text/javascript">
 async function fetchLatestReleaseInfo() {
-  const url = "https://api.github.com/repos/bluerobotics/BlueOS/releases/latest";
+  const url = "https://api.github.com/repos/bluerobotics/BlueOS/releases/tags/1.4.2";
 
   const response = await fetch(url)
   if (!response.ok) {


### PR DESCRIPTION
# 🔎 [PREVIEW](http://br-www-docs.s3-website-us-east-1.amazonaws.com/preview/blueos/64/usage/installation/) 🔍

[RPi image creation is broken in CI](https://github.com/bluerobotics/BlueOS/issues/3711) - this at least provides valid links for the latest available RPi images.

I would prefer if we can upload RPi images to the 1.4.3 release and try to fix CI in the meantime instead of merging this, but if that's likely to take some time then this can serve as a stop-gap (as long as it gets reverted once image building and release inclusion is working again.