### PR TITLE
content: usage: installation: Use latest API

### DIFF
--- a/content/usage/installation.md
+++ b/content/usage/installation.md
@@ -73,7 +73,7 @@ For developers with alternative hardware, or who would rather install over a pre
 
 <script type="text/javascript">
 async function fetchLatestReleaseInfo() {
-  const url = "https://api.github.com/repos/bluerobotics/BlueOS/releases/tags/1.4.2";
+  const url = "https://api.github.com/repos/bluerobotics/BlueOS/releases/latest";
 
   const response = await fetch(url)
   if (!response.ok) {


### PR DESCRIPTION
# 🔎 [PREVIEW](http://br-www-docs.s3-website-us-east-1.amazonaws.com/preview/blueos/72/usage/installation) 🔍

The latest endpoint is pointing to 1.4.5 again.